### PR TITLE
Deleted savepoint functionality

### DIFF
--- a/src/main/java/org/mariadb/r2dbc/MariadbConnection.java
+++ b/src/main/java/org/mariadb/r2dbc/MariadbConnection.java
@@ -81,14 +81,7 @@ public final class MariadbConnection implements org.mariadb.r2dbc.api.MariadbCon
 
   @Override
   public Mono<Void> createSavepoint(String name) {
-    Assert.requireNonNull(name, "name must not be null");
-    Mono<Void> needsBegin = isAutoCommit() ? this.client.beginTransaction() : Mono.empty();
-    String cmd = String.format("SAVEPOINT `%s`", name.replace("`", "``"));
-    return needsBegin.then(
-        client
-            .sendCommand(new QueryPacket(cmd), true)
-            .handle(ExceptionFactory.withSql(cmd)::handleErrorResponse)
-            .then());
+    throw new UnsupportedOperationException("Savepoints are not supported in SingleStore");
   }
 
   @Override
@@ -126,12 +119,7 @@ public final class MariadbConnection implements org.mariadb.r2dbc.api.MariadbCon
 
   @Override
   public Mono<Void> releaseSavepoint(String name) {
-    Assert.requireNonNull(name, "name must not be null");
-    String cmd = String.format("RELEASE SAVEPOINT `%s`", name.replace("`", "``"));
-    return client
-        .sendCommand(new QueryPacket(cmd), true)
-        .handle(ExceptionFactory.withSql(cmd)::handleErrorResponse)
-        .then();
+    throw new UnsupportedOperationException("Savepoints are not supported in SingleStore");
   }
 
   @Override
@@ -166,8 +154,7 @@ public final class MariadbConnection implements org.mariadb.r2dbc.api.MariadbCon
 
   @Override
   public Mono<Void> rollbackTransactionToSavepoint(String name) {
-    Assert.requireNonNull(name, "name must not be null");
-    return this.client.rollbackTransactionToSavepoint(name);
+    throw new UnsupportedOperationException("Savepoints are not supported in SingleStore");
   }
 
   @Override

--- a/src/main/java/org/mariadb/r2dbc/client/Client.java
+++ b/src/main/java/org/mariadb/r2dbc/client/Client.java
@@ -74,8 +74,6 @@ public interface Client {
 
   Mono<Void> setAutoCommit(boolean autoCommit);
 
-  Mono<Void> rollbackTransactionToSavepoint(String name);
-
   long getThreadId();
 
   HostAddress getHostAddress();

--- a/src/main/java/org/mariadb/r2dbc/client/FailoverClient.java
+++ b/src/main/java/org/mariadb/r2dbc/client/FailoverClient.java
@@ -589,19 +589,6 @@ public class FailoverClient implements Client {
   }
 
   @Override
-  public Mono<Void> rollbackTransactionToSavepoint(String name) {
-    return client
-        .get()
-        .rollbackTransactionToSavepoint(name)
-        .onErrorResume(
-            FAIL_PREDICATE,
-            t ->
-                reconnectFallbackReplay(t, conf, lock, client, true, true, null)
-                    .map(c -> c.rollbackTransactionToSavepoint(name))
-                    .flatMap(flux -> flux));
-  }
-
-  @Override
   public long getThreadId() {
     return client.get().getThreadId();
   }

--- a/src/main/java/org/mariadb/r2dbc/client/SimpleClient.java
+++ b/src/main/java/org/mariadb/r2dbc/client/SimpleClient.java
@@ -467,16 +467,6 @@ public class SimpleClient implements Client {
   }
 
   /**
-   * Specific implementation, to avoid executing ROLLBACK TO TRANSACTION if no transaction
-   *
-   * @return publisher
-   */
-  public Mono<Void> rollbackTransactionToSavepoint(String name) {
-    String sql = String.format("ROLLBACK TO SAVEPOINT `%s`", name.replace("`", "``"));
-    return executeWhenTransaction(sql);
-  }
-
-  /**
    * Specific implementation, to avoid changing autocommit mode if already in this autocommit mode
    *
    * @return publisher

--- a/src/test/java/org/mariadb/r2dbc/integration/MariadbBinaryTestKit.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/MariadbBinaryTestKit.java
@@ -8,6 +8,7 @@ import io.r2dbc.spi.test.TestKit;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.mariadb.r2dbc.MariadbConnectionConfiguration;
 import org.mariadb.r2dbc.MariadbConnectionFactory;
@@ -96,5 +97,15 @@ public class MariadbBinaryTestKit implements TestKit<String> {
   @Override
   public String clobType() {
     return "TEXT";
+  }
+
+  @Override
+  @Disabled
+  public void savePointStartsTransaction() {
+  }
+
+  @Override
+  @Disabled
+  public void savePoint() {
   }
 }

--- a/src/test/java/org/mariadb/r2dbc/integration/MariadbTextTestKit.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/MariadbTextTestKit.java
@@ -8,6 +8,7 @@ import io.r2dbc.spi.test.TestKit;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 import org.mariadb.jdbc.MariaDbDataSource;
 import org.mariadb.r2dbc.MariadbConnectionConfiguration;
 import org.mariadb.r2dbc.MariadbConnectionFactory;
@@ -90,5 +91,15 @@ public class MariadbTextTestKit implements TestKit<String> {
   @Override
   public String clobType() {
     return "TEXT";
+  }
+
+  @Override
+  @Disabled
+  public void savePointStartsTransaction() {
+  }
+
+  @Override
+  @Disabled
+  public void savePoint() {
   }
 }


### PR DESCRIPTION
SingleStore doesn't support [SAVEPOINT](https://mariadb.com/docs/server/reference/sql-statements/transactions/savepoint)