### PR TITLE
Fixed tests

### DIFF
--- a/src/test/java/org/mariadb/r2dbc/integration/StatementBatchingTest.java
+++ b/src/test/java/org/mariadb/r2dbc/integration/StatementBatchingTest.java
@@ -39,7 +39,7 @@ public class StatementBatchingTest extends BaseConnectionTest {
         .blockLast();
 
     connection
-        .createStatement("SELECT * FROM batchStatement")
+        .createStatement("SELECT * FROM batchStatement ORDER BY id")
         .execute()
         .flatMap(r -> r.map((row, metadata) -> row.get(0, String.class) + row.get(1, String.class)))
         .as(StepVerifier::create)


### PR DESCRIPTION
Sorted results of queries to guarantee deterministic ordering.
Replaced ZEROFILL column with simple INT. Updated its metadata.
Created seq tables manually.
Fixed variable declaration statement.
Deleted AUTO_INCREMENT step tests, as this functionality is not supported in SingleStore.
Enabled several tests.